### PR TITLE
Implement cache at interface level using cache contracts

### DIFF
--- a/bin/dbgserv.php
+++ b/bin/dbgserv.php
@@ -1,6 +1,8 @@
 <?php
 
 include_once __DIR__."/../vendor/autoload.php";
+include_once __DIR__."/../tests/bootstrap.php";
+
 use HelioviewerEventInterface\Events;
 
 $sources = $_GET['sources'] ?? null;

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -3,9 +3,11 @@
 namespace HelioviewerEventInterface;
 
 use \DateInterval;
+use \DateTimeInterface;
 use \Redis;
 use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Contracts\Cache\ItemInterface;
 
 class Cache {
     private static ?RedisAdapter $CacheInstance = null;
@@ -16,6 +18,42 @@ class Cache {
             self::$CacheInstance = new RedisAdapter($redis);
         }
         return self::$CacheInstance;
+    }
+
+    public static function DefaultExpiry(): DateInterval {
+        return new DateInterval("P2W");
+    }
+
+    /**
+     * Creates a unique ID that is associated with the given identifier and provided date range.
+     *
+     * @param string $id Primary cache key identifier
+     * @param DateTimeInterface $date Date to integrate into the resulting key
+     * @param DateInterval $interval Length of time to integrate into the resulting key
+     */
+    public static function CreateKey(string $id, DateTimeInterface $date, DateInterval $interval): string {
+        // This should be unique across all data sources
+        // Stop the date at hour so that caching occurs on the hour boundary.
+        // The interval uses the full interval value so that different time intervals result in different cache keys.
+        $id .= $date->format('Y-m-d H') . $interval->format('%Y%M%D%H%I%S');
+        return hash('sha256', $id);
+    }
+
+    /**
+     * Attempts to retrieve an item from the cache.
+     * On cache miss, the provided function will be executed and the value returned will be saved in the cache.
+     * While the provided function is executing, other cache gets on the same key will be blocked until the function sets the cached value.
+     * This prevents multiple "threads" from trying to compute the key simultaneously.
+     * In the context of this project, it's for limiting external HTTP requests to reduce the load on external servers.
+     * @param string $key Cache key
+     * @param DateInterval $expiry Length of time for this item to live.
+     * @param callable $computeValue Function which will compute the value to cache for this key.
+     */
+    public static function GetWithLock(string $key, DateInterval $expiry, callable $computeValue): mixed {
+        return self::GetCacheInstance()->get($key, function (ItemInterface $item) use ($expiry, $computeValue) {
+            $item->expiresAfter($expiry);
+            return $computeValue();
+        });
     }
 
     /**
@@ -37,5 +75,14 @@ class Cache {
         $item->expiresAfter($expiration);
         $item->set($value);
         self::GetCacheInstance()->save($item);
+    }
+
+    /**
+     * Clears the cache of all keys
+     */
+    public static function Clear(): void {
+        $redis = new Redis();
+        $redis->connect(HV_REDIS_HOST, HV_REDIS_PORT);
+        $redis->flushAll();
     }
 }

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -3,6 +3,7 @@
 namespace HelioviewerEventInterface;
 
 use \DateInterval;
+use \DateTime;
 use \DateTimeInterface;
 use \Redis;
 use Psr\Cache\CacheItemInterface;
@@ -22,6 +23,20 @@ class Cache {
 
     public static function DefaultExpiry(): DateInterval {
         return new DateInterval("P2W");
+    }
+
+    /**
+     * Rounds the given date to the nearest hour.
+     */
+    public static function RoundDate(DateTimeInterface $date): DateTimeInterface {
+        // Round query date to the nearest hour
+        $roundedDateTime = new DateTime();
+        // dividing by 3600 (1 hour) will give a float where the decimal portion is the minutes/seconds
+        // Rounding this will round the time to the nearest hour
+        // Then multiply back by 3600 to get a valid date
+        $roundedTimestamp = intval(round($date->getTimestamp() / 3600) * 3600);
+        $roundedDateTime->setTimestamp($roundedTimestamp);
+        return $roundedDateTime;
     }
 
     /**

--- a/src/DataSource.php
+++ b/src/DataSource.php
@@ -85,14 +85,7 @@ class DataSource {
      * @return PromiseInterface
      */
     public function beginQuery(DateTimeInterface $start, DateInterval $length, ?callable $postprocessor = null) {
-        // Round query date to the nearest hour
-        $roundedDateTime = new DateTime();
-        // dividing by 3600 (1 hour) will give a float where the decimal portion is the minutes/seconds
-        // Rounding this will round the time to the nearest hour
-        // Then multiply back by 3600 to get a valid date
-        $roundedTimestamp = intval(round($start->getTimestamp() / 3600) * 3600);
-        $roundedDateTime->setTimestamp($roundedTimestamp);
-
+        $roundedDateTime = Cache::RoundDate($start);
         $this->cache = Cache::Get($this->GetCacheKey($roundedDateTime, $length));
         // Only send the request on cache miss
         if (!$this->cache->isHit()) {

--- a/src/DataSource.php
+++ b/src/DataSource.php
@@ -47,10 +47,7 @@ class DataSource {
     public function GetCacheKey(\DateTimeInterface $date, \DateInterval $interval): string {
         // This should be unique across all data sources
         $data = "$this->source $this->name " . json_encode($this->queryParameters) . json_encode($this->extra);
-        // Stop the date at hour so that caching occurs on the hour boundary.
-        // The interval uses the full interval value so that different time intervals result in different cache keys.
-        $data .= $date->format('Y-m-d H') . $interval->format('%Y%M%D%H%I%S');
-        return hash('sha256', $data);
+        return Cache::CreateKey($data, $date, $interval);
     }
 
     /**
@@ -168,7 +165,7 @@ class DataSource {
             $result = $this->BuildEventCategory($groups);
             // Cache item must be set during beginQuery even if its a cache miss.
             $key = $this->cache->getKey();
-            Cache::Set($key, new DateInterval("P2W"), $result);
+            Cache::Set($key, Cache::DefaultExpiry(), $result);
             return $result;
         }
         error_log("Attempted to get the result without calling beginQuery");

--- a/src/DataSource.php
+++ b/src/DataSource.php
@@ -9,7 +9,6 @@ use \DateTimeInterface;
 use \Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Request;
 use Psr\Cache\CacheItemInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/src/Events.php
+++ b/src/Events.php
@@ -20,6 +20,7 @@ class Events
      * Returns all data provided by the event interface.
      */
     public static function GetAll(DateTimeInterface $start, DateInterval $length, ?callable $postprocessor = null): array {
+        $start = Cache::RoundDate($start);
         $key = self::GetCacheKey("AllSources", $start, $length);
         return Cache::GetWithLock($key, Cache::DefaultExpiry(), function () use ($start, $length, $postprocessor) {
             return Events::Get($start, $length, Sources::All(), $postprocessor);
@@ -31,6 +32,7 @@ class Events
      * @param array $sources Array of strings that name the sources to query.
      */
     public static function GetFromSource(array $sources, DateTimeInterface $start, DateInterval $length, ?callable $postprocessor = null): array {
+        $start = Cache::RoundDate($start);
         // Sort first so that the same sources will return the same cache key.
         sort($sources);
         $key = self::GetCacheKey(json_encode($sources), $start, $length);

--- a/src/Events.php
+++ b/src/Events.php
@@ -12,14 +12,18 @@ use HelioviewerEventInterface\Sources;
  */
 class Events
 {
+    protected static function GetCacheKey(string $sources, DateTimeInterface $date, DateInterval $length): string {
+        return Cache::CreateKey($sources, $date, $length);
+    }
+
     /**
      * Returns all data provided by the event interface.
      */
-    public static function GetAll(DateTimeInterface $start, DateInterval $length, ?callable $postprocessor = null, array $sources = null): array {
-        if (is_null($sources)) {
-            $sources = Sources::All();
-        }
-        return Events::Get($start, $length, $sources, $postprocessor);
+    public static function GetAll(DateTimeInterface $start, DateInterval $length, ?callable $postprocessor = null): array {
+        $key = self::GetCacheKey("AllSources", $start, $length);
+        return Cache::GetWithLock($key, Cache::DefaultExpiry(), function () use ($start, $length, $postprocessor) {
+            return Events::Get($start, $length, Sources::All(), $postprocessor);
+        });
     }
 
     /**
@@ -27,8 +31,13 @@ class Events
      * @param array $sources Array of strings that name the sources to query.
      */
     public static function GetFromSource(array $sources, DateTimeInterface $start, DateInterval $length, ?callable $postprocessor = null): array {
+        // Sort first so that the same sources will return the same cache key.
+        sort($sources);
+        $key = self::GetCacheKey(json_encode($sources), $start, $length);
         $sources = Sources::FromArray($sources);
-        return Events::Get($start, $length, $sources, $postprocessor);
+        return Cache::GetWithLock($key, Cache::DefaultExpiry(), function () use ($sources, $start, $length, $postprocessor) {
+            return Events::Get($start, $length, $sources, $postprocessor);
+        });
     }
 
     /**

--- a/src/Sources.php
+++ b/src/Sources.php
@@ -32,7 +32,7 @@ class Sources {
         $all = Sources::All();
         // Return all datasources where the source name is in the given source array
         return array_filter($all, function ($datasource) use ($sources) {
-            return in_array($datasource->source, $sources);
+            return in_array($datasource->source, $sources) || in_array($datasource->name, $sources);
         });
     }
 }

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-use HelioviewerEventInterface\DataSource;
+use HelioviewerEventInterface\Cache;
 use HelioviewerEventInterface\Events;
 use PHPUnit\Framework\TestCase;
 
@@ -14,15 +14,17 @@ final class EventsTest extends TestCase
         $this->LENGTH = new DateInterval('P1D');
     }
 
+    protected function setUp(): void
+    {
+        Cache::Clear();
+    }
+
     /**
      * Verifies that events can be queried and that the closure to modify individual records is working
      */
     public function testGetEvents(): void
     {
-        $sources = [
-            new DataSource("DONKI", "Coronal Mass Ejection", "CE", "https://kauai.ccmc.gsfc.nasa.gov/DONKI/WS/get/CME", "startDate", "endDate", "Y-m-d", false, DonkiCme::class),
-        ];
-        $result = Events::GetAll($this->START_DATE, $this->LENGTH, function ($record) {$record->hv_hpc_x = 999; return $record;}, $sources);
+        $result = Events::GetFromSource(["DONKI"], $this->START_DATE, $this->LENGTH, function ($record) {$record->hv_hpc_x = 999; return $record;});
         $this->assertTrue(is_array($result));
         $this->assertEquals(1, count($result));
         $this->assertTrue(array_key_exists('groups', $result[0]));
@@ -55,6 +57,51 @@ final class EventsTest extends TestCase
         $start = new DateTime();
         $start->sub($length);
         Events::GetAll($start, $length);
+    }
+
+    /**
+     * Tests that the cache lock mechanism to prevent multiple requests is working.
+     */
+    public function testCacheLock(): void {
+        // Create a temporary directory which will be used to track execution of parallel code
+        $tmpdir = sys_get_temp_dir() . "/phpunit_test";
+        if (is_dir($tmpdir)) {
+            exec("rm -r " . $tmpdir);
+        }
+        mkdir($tmpdir);
+
+        // Fork the process so that we can simulate parallel requests
+        $pid = pcntl_fork();
+        if ($pid == -1) {
+            $this->assertTrue(false, "Fork failed");
+        } else if ($pid) {
+            // Parent process. When postprocessor is executed, create a file in the temp directory.
+            Events::GetFromSource(["DONKI"], $this->START_DATE, $this->LENGTH, function ($e) use ($tmpdir) {
+                touch($tmpdir . "/parent");
+                return $e;
+            });
+            error_log("Finished parent\n");
+        } else {
+            // Child process. This should run in parallel with the parent process.
+            // When the post processor runs, create a temp file in the temp directory
+            Events::GetFromSource(["DONKI"], $this->START_DATE, $this->LENGTH, function ($e) use ($tmpdir) {
+                touch($tmpdir . "/child");
+                return $e;
+            });
+            error_log("Finished child\n");
+            // End the child process here.
+            exit;
+        }
+
+        // Now if the lock is working, then only one file will be created.
+        // This is because one of the above functions will race to get the cache lock.
+        // Once one has the lock, the other will not perform any HTTP request or event processing.
+        // It will wait for the value to be computed and stored in the cache, then return the cached value.
+        // Only one will perform the request and postprocessing.
+        $files = scandir($tmpdir);
+        // Remove the linux . and .. from the list
+        $files = array_diff($files, ['.', '..']);
+        $this->assertCount(1, $files);
     }
 }
 

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -80,7 +80,6 @@ final class EventsTest extends TestCase
                 touch($tmpdir . "/parent");
                 return $e;
             });
-            error_log("Finished parent\n");
         } else {
             // Child process. This should run in parallel with the parent process.
             // When the post processor runs, create a temp file in the temp directory
@@ -88,7 +87,6 @@ final class EventsTest extends TestCase
                 touch($tmpdir . "/child");
                 return $e;
             });
-            error_log("Finished child\n");
             // End the child process here.
             exit;
         }


### PR DESCRIPTION
This updates the Events interface to use the symfony cache contract interface. This uses a locking mechanism so that there is only ever one outstanding request for a given cache key. This means multiple users requesting the same date at the same time will only result in one external request.

This extends the existing implementation. Each data source will cache its own requests, then the overall interface will also cache grouped requests.