### PR TITLE
Handle upstream timeouts

### DIFF
--- a/bin/dbgserv.php
+++ b/bin/dbgserv.php
@@ -12,9 +12,9 @@ $length = $_GET['length'] ?? 'P1D';
 $length = new DateInterval($length);
 
 if (isset($sources)) {
-    $data = Events::GetFromSource($sources, $startDate, $length, null);
+    $data = Events::GetFromSource($sources, $startDate, $length, $startDate);
 } else {
-    $data = Events::GetAll($startDate, $length);
+    $data = Events::GetAll($startDate, $length, $startDate);
 }
 header("Content-Type: application/json");
 echo json_encode($data);

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -31,6 +31,10 @@ class Cache {
         return self::$CacheInstance;
     }
 
+    public static function InvalidateKey(string $key): void {
+        self::GetCacheInstance()->delete($key);
+    }
+
     public static function DefaultExpiry(DateTimeInterface $date): DateInterval {
         $one_week_ago = new DateTime();
         $one_week_ago->sub(new DateInterval('P1W'));

--- a/src/Data/DataSource.php
+++ b/src/Data/DataSource.php
@@ -59,7 +59,10 @@ abstract class DataSource {
 
     protected static function GetClient(): Client {
         if (is_null(self::$HttpClient)) {
-            self::$HttpClient = new Client([]);
+            self::$HttpClient = new Client([
+                // Timeout at 10 seconds.
+                'timeout' => 10.0
+            ]);
         }
         return self::$HttpClient;
     }


### PR DESCRIPTION
This change sets a timeout limit of 10 seconds.
For requests that complete within 10 seconds, their results are cached for future use.
For requests that time out, the data returned excludes those results, and future requests will retry the query.