### PR TITLE
Filter out solar flare predictions with invalid coordinates

### DIFF
--- a/src/Translator/FlarePrediction.php
+++ b/src/Translator/FlarePrediction.php
@@ -8,6 +8,7 @@ use HelioviewerEventInterface\Coordinator\Coordinator;
 use HelioviewerEventInterface\Types\HelioviewerEvent;
 use HelioviewerEventInterface\Util\Date;
 use HelioviewerEventInterface\Util\HapiRecord;
+use HelioviewerEventInterface\Util\LocationParser;
 
 const FLARE_CLASSES = ["C", "CPlus", "M", "MPlus", "X"];
 
@@ -68,6 +69,13 @@ class FlarePrediction {
         foreach ($events['groups'] as &$group) {
             // $group:
             // array('name', 'contact', 'url', 'data')
+
+            // We have identified that some predictions in CCMC have invalid
+            // coordinates. In this case, we are going to drop these values
+            // from the list.
+            $group['data'] = array_filter($group['data'], function ($event) {
+                return LocationParser::IsValidLatitudeLongitude(GetLatitude($event['source']), GetLongitude($event['source']));
+            });
             foreach ($group['data'] as &$event) {
                 // event:
                 // array of HelioviewerEvent fields

--- a/src/Translator/FlarePrediction.php
+++ b/src/Translator/FlarePrediction.php
@@ -73,9 +73,9 @@ class FlarePrediction {
             // We have identified that some predictions in CCMC have invalid
             // coordinates. In this case, we are going to drop these values
             // from the list.
-            $group['data'] = array_filter($group['data'], function ($event) {
+            $group['data'] = array_values(array_filter($group['data'], function ($event) {
                 return LocationParser::IsValidLatitudeLongitude(GetLatitude($event['source']), GetLongitude($event['source']));
-            });
+            }));
             foreach ($group['data'] as &$event) {
                 // event:
                 // array of HelioviewerEvent fields

--- a/src/Util/LocationParser.php
+++ b/src/Util/LocationParser.php
@@ -20,4 +20,11 @@ class LocationParser
         $longitude = $east_west == "E" ? -$east_west_value : $east_west_value;
         return [$latitude, $longitude];
     }
+
+    /**
+     * Verifies that the latitude and longitude are valid coordinates
+     */
+    public static function IsValidLatitudeLongitude(float $lat, float $lon): bool {
+        return (-90 <= $lat && $lat <= 90) && (-180 <= $lon && $lon <= 180);
+    }
 }


### PR DESCRIPTION
Filters out solar flare predictions with invalid coordinates. These coordinates can't be converted into a valid event position, so we drop them.